### PR TITLE
fix: venus-wallet: change to  build docker image from local repo 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,6 @@ print-%:
 
 .PHONY: docker
 
-BUILD_DOCKER_PROXY=
 
 docker:
 	docker build --build-arg https_proxy=$(BUILD_DOCKER_PROXY) -t venus .

--- a/dockerfile
+++ b/dockerfile
@@ -1,6 +1,6 @@
 FROM filvenus/venus-buildenv AS buildenv
 
-RUN git clone https://github.com/filecoin-project/venus-wallet.git --depth 1 
+COPY . ./venus-wallet
 RUN export GOPROXY=https://goproxy.cn && cd venus-wallet  && make
 
 RUN cd venus-wallet && ldd ./venus-wallet
@@ -17,17 +17,17 @@ COPY ./docker/script  /script
 
 # copy ddl
 COPY --from=buildenv   /usr/lib/x86_64-linux-gnu/libhwloc.so.5  \
-                        /usr/lib/x86_64-linux-gnu/libOpenCL.so.1  \
-                        /lib/x86_64-linux-gnu/libgcc_s.so.1  \
-                        /lib/x86_64-linux-gnu/libutil.so.1  \
-                        /lib/x86_64-linux-gnu/librt.so.1  \
-                        /lib/x86_64-linux-gnu/libpthread.so.0  \
-                        /lib/x86_64-linux-gnu/libm.so.6  \
-                        /lib/x86_64-linux-gnu/libdl.so.2  \
-                        /lib/x86_64-linux-gnu/libc.so.6  \
-                        /usr/lib/x86_64-linux-gnu/libnuma.so.1  \
-                        /usr/lib/x86_64-linux-gnu/libltdl.so.7  \
-                        /lib/
+    /usr/lib/x86_64-linux-gnu/libOpenCL.so.1  \
+    /lib/x86_64-linux-gnu/libgcc_s.so.1  \
+    /lib/x86_64-linux-gnu/libutil.so.1  \
+    /lib/x86_64-linux-gnu/librt.so.1  \
+    /lib/x86_64-linux-gnu/libpthread.so.0  \
+    /lib/x86_64-linux-gnu/libm.so.6  \
+    /lib/x86_64-linux-gnu/libdl.so.2  \
+    /lib/x86_64-linux-gnu/libc.so.6  \
+    /usr/lib/x86_64-linux-gnu/libnuma.so.1  \
+    /usr/lib/x86_64-linux-gnu/libltdl.so.7  \
+    /lib/
 
 
 EXPOSE 5680


### PR DESCRIPTION
## Related Issues
<!-- link all issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made.-->

## Proposed Changes
<!-- provide a clear list of the changes being made-->

change to build docker image from local repo rather than from git chech out
pass env var BUILD_DOCKER_PROXY to docker when make image